### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,10 +18,8 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/stale.yml` file to update the stale issue and pull request handling messages and timing.

Changes to stale issue and pull request handling:

* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L23-R25): Updated the `stale-issue-message` to specify that issues will be marked stale after 30 days of inactivity and will be closed in 5 days if no further activity occurs.
* [`.github/workflows/stale.yml`](diffhunk://#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894L23-R25): Added `days-before-stale` and `days-before-close` parameters to configure the timing for marking issues as stale and closing them.